### PR TITLE
Fix dropping wrong priority

### DIFF
--- a/queue_test.go
+++ b/queue_test.go
@@ -85,30 +85,58 @@ func TestDropLast(t *testing.T) {
 }
 
 func BenchmarkQueue(b *testing.B) {
-	q := newQueue(b.N)
-	r := rendezvouz{}
+	b.Run("newQueue", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			newQueue(10)
+		}
 
-	for i := 0; i < b.N; i++ {
-		q.Push(&r)
-	}
-}
+	})
 
-func BenchmarkQueueFull(b *testing.B) {
-	q := newQueue(10)
+	b.Run("Push", func(b *testing.B) {
+		b.Run("Empty", func(b *testing.B) {
+			q := newQueue(b.N)
+			r := rendezvouz{}
 
-	for i := 0; i < 10; i++ {
-		r := &rendezvouz{}
-		q.Push(r)
-	}
+			for i := 0; i < b.N; i++ {
+				q.Push(&r)
+			}
 
-	for i := 0; i < b.N; i++ {
-		r := &rendezvouz{priority: i + 1}
-		q.Push(r)
-	}
-}
+		})
 
-func BenchmarkQueueAllocs(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		newQueue(10)
-	}
+		b.Run("Full", func(b *testing.B) {
+			q := newQueue(10)
+
+			for i := 0; i < 10; i++ {
+				r := &rendezvouz{}
+				q.Push(r)
+			}
+
+			for i := 0; i < b.N; i++ {
+				r := &rendezvouz{priority: i + 1}
+				q.Push(r)
+			}
+		})
+	})
+
+	b.Run("Pop", func(b *testing.B) {
+		q := newQueue(b.N)
+
+		for i := 0; i < b.N; i++ {
+			r := rendezvouz{}
+			q.Push(&r)
+		}
+
+		b.ResetTimer()
+
+		var out *rendezvouz
+
+		for i := 0; i < b.N; i++ {
+			out = q.Pop()
+		}
+
+		if out != nil {
+		}
+
+	})
+
 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -1,6 +1,7 @@
 package congestion
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -12,6 +13,7 @@ func TestPriority(t *testing.T) {
 		{[]int{0, 1}, 1},
 		{[]int{1, 0}, 1},
 		{[]int{0, 2, 1}, 2},
+		{[]int{0, 2, 1, 3, 7, 8}, 8},
 	}
 
 	for _, tc := range cases {
@@ -20,6 +22,7 @@ func TestPriority(t *testing.T) {
 			r := rendezvouz{priority: p}
 			q.Push(&r)
 		}
+
 		actual := q.Pop().priority
 		if actual != tc.Expected {
 			t.Errorf("Priority %v = %d, expected %d", tc.Priorities, actual, tc.Expected)
@@ -47,23 +50,36 @@ func TestRemove(t *testing.T) {
 }
 
 func TestDropLast(t *testing.T) {
-	a := rendezvouz{priority: 0, errChan: make(chan error, 1)}
-	b := rendezvouz{priority: 1, errChan: make(chan error, 1)}
-	c := rendezvouz{priority: 2, errChan: make(chan error, 1)}
+	cases := []int{2, 3, 4, 5, 6, 7, 8}
 
-	q := newQueue(2)
+	for _, c := range cases {
+		c := c
+		t.Run(fmt.Sprintf("%d", c), func(t *testing.T) {
+			a := rendezvouz{priority: 0, errChan: make(chan error, 1)}
 
-	for _, r := range []*rendezvouz{&a, &b, &c} {
-		q.Push(r)
-	}
+			q := newQueue(c)
+			q.Push(&a)
 
-	if q.Len() != 2 {
-		t.Errorf("Got %d, expected %d", 2, q.Len())
-	}
+			for i := 0; i < c; i++ {
+				r := rendezvouz{priority: i + 1, errChan: make(chan error, 1)}
+				q.Push(&r)
+			}
 
-	dropped := <-a.errChan
-	if dropped != Dropped {
-		t.Errorf("Got %d, expected %d", dropped, Dropped)
+			if q.Len() != c {
+				t.Errorf("Got %d, expected %d", c, q.Len())
+			}
+
+			var dropped error
+
+			select {
+			case dropped = <-a.errChan:
+			default:
+			}
+
+			if dropped != Dropped {
+				t.Errorf("Got %d, expected %d", dropped, Dropped)
+			}
+		})
 	}
 
 }
@@ -74,6 +90,20 @@ func BenchmarkQueue(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		q.Push(&r)
+	}
+}
+
+func BenchmarkQueueFull(b *testing.B) {
+	q := newQueue(10)
+
+	for i := 0; i < 10; i++ {
+		r := &rendezvouz{}
+		q.Push(r)
+	}
+
+	for i := 0; i < b.N; i++ {
+		r := &rendezvouz{priority: i + 1}
+		q.Push(r)
 	}
 }
 


### PR DESCRIPTION
There was an issue where the lowest priority may not be dropped when
trying running `Limiter.Acquire`.