### PR TITLE
Fix queue indexing

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -98,9 +98,13 @@ func (pq *priorityQueue) Push(r *rendezvouz) bool {
 	last := (*pq)[lowestIndex]
 	if last.priority < r.priority {
 		(*pq)[lowestIndex] = r
+
+		// Fix index
 		r.index = lowestIndex
 		heap.Fix((*queue)(pq), lowestIndex)
 
+		// For safety
+		last.index = -1
 		last.Drop()
 
 		return true

--- a/queue.go
+++ b/queue.go
@@ -98,6 +98,7 @@ func (pq *priorityQueue) Push(r *rendezvouz) bool {
 	last := (*pq)[lowestIndex]
 	if last.priority < r.priority {
 		(*pq)[lowestIndex] = r
+		r.index = lowestIndex
 		heap.Fix((*queue)(pq), lowestIndex)
 
 		last.Drop()

--- a/queue_test.go
+++ b/queue_test.go
@@ -3,6 +3,8 @@ package congestion
 import (
 	"fmt"
 	"testing"
+
+	"github.com/flyingmutant/rapid"
 )
 
 func TestPriority(t *testing.T) {
@@ -179,4 +181,77 @@ func BenchmarkQueue(b *testing.B) {
 
 	})
 
+}
+
+type queueMachine struct {
+	q *priorityQueue // queue being tested
+	n int            // maximum queue size
+}
+
+// Init is an action for initializing  a queueMachine instance.
+func (m *queueMachine) Init(t *rapid.T) {
+	n := rapid.IntRange(1, 3).Draw(t, "n").(int)
+	q := newQueue(n)
+	m.q = &q
+	m.n = n
+}
+
+// Model of Push
+func (m *queueMachine) Push(t *rapid.T) {
+	r := rendezvouz{
+		priority: rapid.Int().Draw(t, "priority").(int),
+		errChan:  make(chan error, 1),
+	}
+
+	m.q.Push(&r)
+}
+
+// Model of Remove
+func (m *queueMachine) Remove(t *rapid.T) {
+	if m.q.Empty() {
+		t.Skip("empty")
+	}
+
+	r := (*m.q)[rapid.IntRange(0, m.q.Len()-1).Draw(t, "i").(int)]
+	m.q.Remove(r)
+}
+
+// Model of Drop
+func (m *queueMachine) Drop(t *rapid.T) {
+	if m.q.Empty() {
+		t.Skip("empty")
+	}
+
+	r := (*m.q)[rapid.IntRange(0, m.q.Len()-1).Draw(t, "i").(int)]
+	r.Drop()
+}
+
+// Model of Signal
+func (m *queueMachine) Pop(t *rapid.T) {
+	if m.q.Empty() {
+		t.Skip("empty")
+	}
+
+	r := m.q.Pop()
+	r.Signal()
+}
+
+// validate that invariants hold
+func (m *queueMachine) Check(t *rapid.T) {
+	if m.q.Len() > m.q.Cap() {
+		t.Fatalf("queue over capacity: %v vs expected %v", m.q.Len(), m.q.Cap())
+	}
+
+	for i, r := range *m.q {
+		if r.index != i {
+			t.Fatalf("illegal index: expected %d, got %+v ", i, r)
+		}
+	}
+
+}
+
+func TestPriorityQueue(t *testing.T) {
+	t.Run("It should meet invariants", func(t *testing.T) {
+		rapid.Check(t, rapid.Run(&queueMachine{}))
+	})
 }


### PR DESCRIPTION
When pushing to a full queue, the index wasn't properly tracked. This
can result in invalid removals.